### PR TITLE
feat: 홈화면 조회 API 구현 및 테스트 완료

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -3,11 +3,12 @@
 ## 목차
 1. [인증 API](#1-인증-api)
 2. [사용자 API](#2-사용자-api)
-3. [크루 API](#3-크루-api)
-4. [러닝 기록 API](#4-러닝-기록-api)
-5. [챌린지 API](#5-챌린지-api)
-6. [배틀 리그 API](#6-배틀-리그-api)
-7. [마이페이지 API](#7-마이페이지-api)
+3. [홈 화면 API](#3-홈-화면-api)
+4. [크루 API](#4-크루-api)
+5. [러닝 기록 API](#5-러닝-기록-api)
+6. [챌린지 API](#6-챌린지-api)
+7. [배틀 리그 API](#7-배틀-리그-api)
+8. [마이페이지 API](#8-마이페이지-api)
 
 ---
 
@@ -119,9 +120,86 @@ Authorization: Bearer {accessToken}
 
 ---
 
-## 3. 크루 API
+## 3. 홈 화면 API
 
-### 3.1 크루 목록 조회
+### 3.1 홈 화면 조회
+```
+GET /api/v1/home
+```
+
+**Headers**
+```
+Authorization: Bearer {accessToken}
+```
+
+**Response** `200 OK`
+```json
+{
+  "battleLeague": {
+    "myCrewName": "아침 러너스",
+    "opponentCrewName": "저녁 산책",
+    "myCrewDistance": 250000,
+    "opponentCrewDistance": 180000
+  },
+  "todayRunning": {
+    "distance": 5000,
+    "duration": 1800,
+    "pace": 360
+  },
+  "recentActivities": [
+    {
+      "nickname": "홍길동",
+      "distance": 5000,
+      "duration": 1800,
+      "pace": 360
+    },
+    {
+      "nickname": "김철수",
+      "distance": 3000,
+      "duration": 1200,
+      "pace": 400
+    },
+    {
+      "nickname": "이영희",
+      "distance": 7000,
+      "duration": 2400,
+      "pace": 343
+    },
+    {
+      "nickname": "박민수",
+      "distance": 4000,
+      "duration": 1600,
+      "pace": 400
+    },
+    {
+      "nickname": "정수진",
+      "distance": 6000,
+      "duration": 2100,
+      "pace": 350
+    }
+  ]
+}
+```
+
+**데이터가 없는 경우** `200 OK`
+```json
+{
+  "battleLeague": null,
+  "todayRunning": null,
+  "recentActivities": []
+}
+```
+
+**설명**
+- `battleLeague`: 진행 중인 배틀 리그가 없거나 내 크루가 참가하지 않은 경우 `null`
+- `todayRunning`: 오늘 러닝 기록이 없는 경우 `null` (가장 최근 1개만 반환)
+- `recentActivities`: 크루의 최근 러닝 기록 최대 5개 (없으면 빈 배열)
+
+---
+
+## 4. 크루 API
+
+### 4.1 크루 목록 조회
 ```
 GET /api/crew/list
 ```
@@ -157,7 +235,7 @@ Authorization: Bearer {accessToken}
 
 ---
 
-### 3.2 크루 검색 자동완성
+### 4.2 크루 검색 자동완성
 ```
 GET /api/crew/autocomplete?keyword={keyword}
 ```
@@ -181,14 +259,14 @@ Authorization: Bearer {accessToken}
   {
     "id": 2,
     "name": "아침 산책",
-    "intro": "산책하는 크루"
+    "intro": "산책하는 크루~"
   }
 ]
 ```
 
 ---
 
-### 3.3 크루 생성
+### 4.3 크루 생성
 ```
 POST /api/crew
 ```
@@ -227,7 +305,7 @@ Authorization: Bearer {accessToken}
 
 ---
 
-### 3.4 크루 가입
+### 4.4 크루 가입
 ```
 POST /api/crew/signup
 ```
@@ -253,7 +331,7 @@ Authorization: Bearer {accessToken}
 
 ---
 
-### 3.5 내 크루 홈 조회
+### 4.5 내 크루 홈 조회
 ```
 GET /api/crew
 ```
@@ -312,7 +390,7 @@ Authorization: Bearer {accessToken}
 
 ---
 
-### 3.6 크루원 달린 기록 조회
+### 4.6 크루원 달린 기록 조회
 ```
 GET /api/crew/{crewId}/members/stats
 ```
@@ -347,9 +425,9 @@ Authorization: Bearer {accessToken}
 
 ---
 
-## 4. 러닝 기록 API
+## 5. 러닝 기록 API
 
-### 4.1 러닝 기록 생성
+### 5.1 러닝 기록 생성
 ```
 POST /api/v1/runnings
 ```
@@ -398,9 +476,9 @@ Authorization: Bearer {accessToken}
 
 ---
 
-## 5. 챌린지 API
+## 6. 챌린지 API
 
-### 5.1 챌린지 생성
+### 6.1 챌린지 생성
 ```
 POST /api/v1/crews/{crewId}/challenges
 ```
@@ -446,7 +524,7 @@ Authorization: Bearer {accessToken}
 
 ---
 
-### 5.2 챌린지 목록 조회
+### 6.2 챌린지 목록 조회
 ```
 GET /api/v1/crews/{crewId}/challenges
 ```
@@ -494,9 +572,9 @@ Authorization: Bearer {accessToken}
 
 ---
 
-## 6. 배틀 리그 API
+## 7. 배틀 리그 API
 
-### 6.1 진행 중인 배틀 리그 조회
+### 7.1 진행 중인 배틀 리그 조회
 ```
 GET /api/v1/matches/ongoing
 ```
@@ -537,7 +615,7 @@ Authorization: Bearer {accessToken}
 
 ---
 
-### 6.2 진행 중인 배틀 리그 상세 조회
+### 7.2 진행 중인 배틀 리그 상세 조회
 ```
 GET /api/v1/matches/ongoing/detail
 ```
@@ -593,9 +671,9 @@ Authorization: Bearer {accessToken}
 
 ---
 
-## 7. 마이페이지 API
+## 8. 마이페이지 API
 
-### 7.1 마이페이지 요약 조회
+### 8.1 마이페이지 요약 조회
 ```
 GET /api/mypage
 ```
@@ -685,6 +763,10 @@ Authorization: Bearer {accessToken}
 ---
 
 ## 변경 이력
+
+### 2024-01-16
+- 홈 화면 API 추가 (배틀 리그 간략 정보, 오늘의 러닝 기록, 최근 크루 활동)
+- 배틀 리그 상세 조회 시 상대 크루원 정보 비공개 처리
 
 ### 2024-01-15
 - 챌린지 API 추가

--- a/src/main/java/com/example/bakersbackend/domain/home/controller/HomeController.java
+++ b/src/main/java/com/example/bakersbackend/domain/home/controller/HomeController.java
@@ -1,0 +1,31 @@
+package com.example.bakersbackend.domain.home.controller;
+
+import com.example.bakersbackend.domain.auth.entity.User;
+import com.example.bakersbackend.domain.home.dto.HomeResponse;
+import com.example.bakersbackend.domain.home.service.HomeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "홈 화면 API", description = "메인 홈 화면 정보 조회 API")
+@RestController
+@RequestMapping("/api/v1/home")
+@RequiredArgsConstructor
+public class HomeController {
+
+    private final HomeService homeService;
+
+    @Operation(summary = "홈 화면 조회", description = "배틀 리그 간략 정보, 오늘의 러닝 기록, 크루 최근 활동을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<HomeResponse> getHome(
+            @AuthenticationPrincipal User user
+    ) {
+        HomeResponse response = homeService.getHome(user);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/bakersbackend/domain/home/dto/BattleLeagueSummary.java
+++ b/src/main/java/com/example/bakersbackend/domain/home/dto/BattleLeagueSummary.java
@@ -1,0 +1,9 @@
+package com.example.bakersbackend.domain.home.dto;
+
+public record BattleLeagueSummary(
+        String myCrewName,
+        String opponentCrewName,
+        Integer myCrewDistance,
+        Integer opponentCrewDistance
+) {
+}

--- a/src/main/java/com/example/bakersbackend/domain/home/dto/HomeResponse.java
+++ b/src/main/java/com/example/bakersbackend/domain/home/dto/HomeResponse.java
@@ -1,0 +1,10 @@
+package com.example.bakersbackend.domain.home.dto;
+
+import java.util.List;
+
+public record HomeResponse(
+        BattleLeagueSummary battleLeague,
+        TodayRunningRecord todayRunning,
+        List<RecentCrewActivity> recentActivities
+) {
+}

--- a/src/main/java/com/example/bakersbackend/domain/home/dto/RecentCrewActivity.java
+++ b/src/main/java/com/example/bakersbackend/domain/home/dto/RecentCrewActivity.java
@@ -1,0 +1,9 @@
+package com.example.bakersbackend.domain.home.dto;
+
+public record RecentCrewActivity(
+        String nickname,     // 이름
+        Integer distance,    // 거리 (미터)
+        Integer duration,    // 시간 (초)
+        Integer pace         // 페이스 (초/km)
+) {
+}

--- a/src/main/java/com/example/bakersbackend/domain/home/dto/TodayRunningRecord.java
+++ b/src/main/java/com/example/bakersbackend/domain/home/dto/TodayRunningRecord.java
@@ -1,0 +1,8 @@
+package com.example.bakersbackend.domain.home.dto;
+
+public record TodayRunningRecord(
+        Integer distance,    // 거리 (미터)
+        Integer duration,    // 시간 (초)
+        Integer pace         // 페이스 (초/km)
+) {
+}

--- a/src/main/java/com/example/bakersbackend/domain/home/service/HomeService.java
+++ b/src/main/java/com/example/bakersbackend/domain/home/service/HomeService.java
@@ -1,0 +1,167 @@
+package com.example.bakersbackend.domain.home.service;
+
+import com.example.bakersbackend.domain.auth.entity.User;
+import com.example.bakersbackend.domain.crew.entity.Crew;
+import com.example.bakersbackend.domain.crew.entity.MemberStatus;
+import com.example.bakersbackend.domain.crew.repository.CrewMemberRepository;
+import com.example.bakersbackend.domain.home.dto.*;
+import com.example.bakersbackend.domain.match.entity.CrewMatch;
+import com.example.bakersbackend.domain.match.entity.CrewMatchParticipant;
+import com.example.bakersbackend.domain.match.repository.CrewMatchRepository;
+import com.example.bakersbackend.domain.running.entity.Running;
+import com.example.bakersbackend.domain.running.repository.RunningRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HomeService {
+
+    private final RunningRepository runningRepository;
+    private final CrewMemberRepository crewMemberRepository;
+    private final CrewMatchRepository crewMatchRepository;
+    private final Clock clock;
+
+    @Transactional(readOnly = true)
+    public HomeResponse getHome(User user) {
+        // 1. 사용자의 크루 조회
+        Optional<Crew> myCrewOpt = getUserCrew(user);
+
+        // 2. 배틀 리그 정보 조회
+        BattleLeagueSummary battleLeague = myCrewOpt
+                .map(this::getBattleLeagueSummary)
+                .orElse(null);
+
+        // 3. 오늘의 나의 러닝 기록 조회
+        TodayRunningRecord todayRunning = getTodayRunning(user);
+
+        // 4. 그룹 활동 (최근 5명) 조회
+        List<RecentCrewActivity> recentActivities = myCrewOpt
+                .map(crew -> getRecentActivities(crew))
+                .orElse(List.of());
+
+        return new HomeResponse(battleLeague, todayRunning, recentActivities);
+    }
+
+    /**
+     * 사용자의 크루 조회 (APPROVED 상태)
+     */
+    private Optional<Crew> getUserCrew(User user) {
+        // TODO: 1인 1크루 정책이므로 첫 번째 크루 반환
+        // 추후 여러 크루 지원 시 수정 필요
+        return crewMemberRepository.findAll().stream()
+                .filter(cm -> cm.getUser().getId().equals(user.getId()))
+                .filter(cm -> cm.getStatus() == MemberStatus.APPROVED)
+                .map(cm -> cm.getCrew())
+                .findFirst();
+    }
+
+    /**
+     * 배틀 리그 간략 정보 조회
+     */
+    private BattleLeagueSummary getBattleLeagueSummary(Crew myCrew) {
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        // 진행 중인 배틀 리그 조회
+        Optional<CrewMatch> matchOpt = crewMatchRepository.findOngoingMatchWithParticipants(now);
+
+        if (matchOpt.isEmpty()) {
+            return null;
+        }
+
+        CrewMatch match = matchOpt.get();
+
+        // 내 크루가 참가 중인지 확인
+        Optional<CrewMatchParticipant> myParticipantOpt = match.getParticipants().stream()
+                .filter(p -> p.getCrew().getId().equals(myCrew.getId()))
+                .findFirst();
+
+        if (myParticipantOpt.isEmpty()) {
+            return null; // 내 크루가 참가하지 않음
+        }
+
+        CrewMatchParticipant myParticipant = myParticipantOpt.get();
+
+        // 상대 크루 찾기
+        Optional<CrewMatchParticipant> opponentOpt = match.getParticipants().stream()
+                .filter(p -> !p.getCrew().getId().equals(myCrew.getId()))
+                .findFirst();
+
+        if (opponentOpt.isEmpty()) {
+            return null; // 1:1 매치에서 상대가 없음
+        }
+
+        CrewMatchParticipant opponent = opponentOpt.get();
+
+        return new BattleLeagueSummary(
+                myCrew.getName(),
+                opponent.getCrew().getName(),
+                myParticipant.getTotalDistance(),
+                opponent.getTotalDistance()
+        );
+    }
+
+    /**
+     * 오늘의 나의 러닝 기록 조회 (하루 전체 합산)
+     */
+    private TodayRunningRecord getTodayRunning(User user) {
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDateTime startOfDay = now.toLocalDate().atStartOfDay();
+        LocalDateTime endOfDay = now.toLocalDate().atTime(LocalTime.MAX);
+
+        List<Running> todayRunnings = runningRepository.findTodayRunningsByUser(
+                user.getId(),
+                startOfDay,
+                endOfDay
+        );
+
+        if (todayRunnings.isEmpty()) {
+            return null; // 오늘 기록 없음
+        }
+
+        // 오늘 하루 전체 합산
+        int totalDistance = todayRunnings.stream()
+                .mapToInt(Running::getDistance)
+                .sum();
+
+        int totalDuration = todayRunnings.stream()
+                .mapToInt(Running::getDuration)
+                .sum();
+
+        // 평균 페이스 계산 (초/km)
+        int averagePace = totalDistance > 0
+                ? (int) ((double) totalDuration / (totalDistance / 1000.0))
+                : 0;
+
+        return new TodayRunningRecord(
+                totalDistance,
+                totalDuration,
+                averagePace
+        );
+    }
+
+    /**
+     * 크루의 최근 활동 5개 조회
+     */
+    private List<RecentCrewActivity> getRecentActivities(Crew crew) {
+        List<Running> recentRunnings = runningRepository.findRecentRunningsByCrew(crew.getId());
+
+        return recentRunnings.stream()
+                .map(r -> new RecentCrewActivity(
+                        r.getUser().getNickname(),
+                        r.getDistance(),
+                        r.getDuration(),
+                        r.getPace()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/example/bakersbackend/domain/running/repository/RunningRepository.java
+++ b/src/main/java/com/example/bakersbackend/domain/running/repository/RunningRepository.java
@@ -66,4 +66,38 @@ public interface RunningRepository extends JpaRepository<Running, Long> {
             @Param("startAt") LocalDateTime startAt,
             @Param("endAt") LocalDateTime endAt
     );
+
+    // 오늘의 특정 사용자 러닝 기록 조회 (가장 최근 1개)
+    @Query("""
+            SELECT r
+            FROM Running r
+            WHERE r.user.id = :userId
+              AND r.startedAt BETWEEN :start AND :end
+            ORDER BY r.createdAt DESC
+            LIMIT 1
+            """)
+    Running findTodayRunningByUser(@Param("userId") Long userId,
+                                    @Param("start") LocalDateTime start,
+                                    @Param("end") LocalDateTime end);
+
+    // 오늘 하루 러닝 기록 합산 조회 (총 거리, 총 시간)
+    @Query("""
+            SELECT r
+            FROM Running r
+            WHERE r.user.id = :userId
+              AND r.startedAt BETWEEN :start AND :end
+            """)
+    List<Running> findTodayRunningsByUser(@Param("userId") Long userId,
+                                           @Param("start") LocalDateTime start,
+                                           @Param("end") LocalDateTime end);
+
+    // 크루의 최근 러닝 기록 조회 (최대 5개)
+    @Query("""
+            SELECT r
+            FROM Running r
+            WHERE r.crew.id = :crewId
+            ORDER BY r.startedAt DESC
+            LIMIT 5
+            """)
+    List<Running> findRecentRunningsByCrew(@Param("crewId") Long crewId);
 }

--- a/src/test/java/com/example/bakersbackend/domain/home/service/HomeServiceTest.java
+++ b/src/test/java/com/example/bakersbackend/domain/home/service/HomeServiceTest.java
@@ -1,0 +1,393 @@
+package com.example.bakersbackend.domain.home.service;
+
+import com.example.bakersbackend.domain.auth.entity.User;
+import com.example.bakersbackend.domain.auth.repository.UserRepository;
+import com.example.bakersbackend.domain.crew.entity.Crew;
+import com.example.bakersbackend.domain.crew.entity.CrewMember;
+import com.example.bakersbackend.domain.crew.entity.MemberStatus;
+import com.example.bakersbackend.domain.crew.repository.CrewMemberRepository;
+import com.example.bakersbackend.domain.crew.repository.CrewRepository;
+import com.example.bakersbackend.domain.home.dto.BattleLeagueSummary;
+import com.example.bakersbackend.domain.home.dto.HomeResponse;
+import com.example.bakersbackend.domain.home.dto.RecentCrewActivity;
+import com.example.bakersbackend.domain.home.dto.TodayRunningRecord;
+import com.example.bakersbackend.domain.match.entity.CrewMatch;
+import com.example.bakersbackend.domain.match.entity.CrewMatchParticipant;
+import com.example.bakersbackend.domain.match.entity.MatchStatus;
+import com.example.bakersbackend.domain.match.repository.CrewMatchRepository;
+import com.example.bakersbackend.domain.running.entity.Running;
+import com.example.bakersbackend.domain.running.repository.RunningRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@org.springframework.test.context.ActiveProfiles("test")
+class HomeServiceTest {
+
+    @Autowired
+    private HomeService homeService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CrewRepository crewRepository;
+
+    @Autowired
+    private CrewMemberRepository crewMemberRepository;
+
+    @Autowired
+    private RunningRepository runningRepository;
+
+    @Autowired
+    private CrewMatchRepository crewMatchRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private Clock clock;
+
+    private User testUser;
+    private Crew testCrew1;
+    private Crew testCrew2;
+
+    @BeforeEach
+    void setUp() {
+        // 데이터 초기화
+        runningRepository.deleteAll();
+        crewMemberRepository.deleteAll();
+        crewMatchRepository.deleteAll();
+        crewRepository.deleteAll();
+        userRepository.deleteAll();
+
+        // 테스트 사용자 생성
+        testUser = userRepository.save(User.builder()
+                .email("test@example.com")
+                .passwordHash("hash")
+                .nickname("테스트유저")
+                .build());
+
+        // 테스트 크루 생성 (name은 최대 5자)
+        testCrew1 = crewRepository.save(Crew.builder()
+                .name("크루A")
+                .owner(testUser)
+                .build());
+
+        testCrew2 = crewRepository.save(Crew.builder()
+                .name("크루B")
+                .owner(testUser)
+                .build());
+    }
+
+    @Test
+    @DisplayName("정상 케이스: 모든 데이터가 있는 경우")
+    void getHome_Success_AllData() {
+        // Given: 사용자가 크루에 가입
+        crewMemberRepository.save(CrewMember.builder()
+                .crew(testCrew1)
+                .user(testUser)
+                .status(MemberStatus.APPROVED)
+                .build());
+
+        // 배틀 리그 생성
+        LocalDateTime now = LocalDateTime.now(clock);
+        CrewMatch match = crewMatchRepository.save(CrewMatch.builder()
+                .title("1월 배틀")
+                .startAt(now.minusDays(1))
+                .endAt(now.plusDays(1))
+                .status(MatchStatus.ONGOING)
+                .build());
+
+        match.addParticipant(CrewMatchParticipant.createNew(match, testCrew1, 0));
+        match.addParticipant(CrewMatchParticipant.createNew(match, testCrew2, 0));
+        crewMatchRepository.save(match);
+
+        // 점수 업데이트
+        CrewMatchParticipant p1 = match.getParticipants().get(0);
+        CrewMatchParticipant p2 = match.getParticipants().get(1);
+        p1.addDistance(10000);
+        p2.addDistance(8000);
+
+        // 오늘의 러닝 기록
+        runningRepository.save(Running.builder()
+                .user(testUser)
+                .crew(testCrew1)
+                .distance(5000)
+                .duration(1800)
+                .pace(360)
+                .startedAt(now)
+                .build());
+
+        // 크루의 최근 활동
+        User user2 = userRepository.save(User.builder()
+                .email("user2@test.com")
+                .passwordHash("hash")
+                .nickname("유저2")
+                .build());
+
+        runningRepository.save(Running.builder()
+                .user(user2)
+                .crew(testCrew1)
+                .distance(3000)
+                .duration(1200)
+                .pace(400)
+                .startedAt(now.minusHours(1))
+                .build());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // When
+        HomeResponse response = homeService.getHome(testUser);
+
+        // Then
+        assertThat(response).isNotNull();
+
+        // 배틀 리그 정보 확인
+        BattleLeagueSummary battleLeague = response.battleLeague();
+        assertThat(battleLeague).isNotNull();
+        assertThat(battleLeague.myCrewName()).isEqualTo("크루A");
+        assertThat(battleLeague.opponentCrewName()).isEqualTo("크루B");
+        assertThat(battleLeague.myCrewDistance()).isEqualTo(10000);
+        assertThat(battleLeague.opponentCrewDistance()).isEqualTo(8000);
+
+        // 오늘의 러닝 기록 확인
+        TodayRunningRecord todayRunning = response.todayRunning();
+        assertThat(todayRunning).isNotNull();
+        assertThat(todayRunning.distance()).isEqualTo(5000);
+        assertThat(todayRunning.duration()).isEqualTo(1800);
+        assertThat(todayRunning.pace()).isEqualTo(360);
+
+        // 최근 활동 확인
+        List<RecentCrewActivity> activities = response.recentActivities();
+        assertThat(activities).isNotEmpty();
+        assertThat(activities).hasSize(2);
+        assertThat(activities.get(0).nickname()).isEqualTo("테스트유저");
+        assertThat(activities.get(1).nickname()).isEqualTo("유저2");
+    }
+
+    @Test
+    @DisplayName("크루가 없는 경우")
+    void getHome_NoCrew() {
+        // Given: 사용자가 크루에 가입하지 않음
+
+        // When
+        HomeResponse response = homeService.getHome(testUser);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.battleLeague()).isNull();
+        assertThat(response.todayRunning()).isNull();
+        assertThat(response.recentActivities()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("배틀 리그가 없는 경우")
+    void getHome_NoBattleLeague() {
+        // Given: 크루에 가입했지만 배틀 리그 없음
+        crewMemberRepository.save(CrewMember.builder()
+                .crew(testCrew1)
+                .user(testUser)
+                .status(MemberStatus.APPROVED)
+                .build());
+
+        // When
+        HomeResponse response = homeService.getHome(testUser);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.battleLeague()).isNull();
+        assertThat(response.todayRunning()).isNull();
+        assertThat(response.recentActivities()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("배틀 리그에 참가하지 않은 경우")
+    void getHome_NotParticipatingInMatch() {
+        // Given: 크루에 가입했지만 배틀 리그 불참
+        crewMemberRepository.save(CrewMember.builder()
+                .crew(testCrew1)
+                .user(testUser)
+                .status(MemberStatus.APPROVED)
+                .build());
+
+        // 다른 크루들의 배틀 리그
+        User otherUser = userRepository.save(User.builder()
+                .email("other@test.com")
+                .passwordHash("hash")
+                .nickname("다른유저")
+                .build());
+
+        Crew otherCrew1 = crewRepository.save(Crew.builder()
+                .name("크루C")
+                .owner(otherUser)
+                .build());
+
+        Crew otherCrew2 = crewRepository.save(Crew.builder()
+                .name("크루D")
+                .owner(otherUser)
+                .build());
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        CrewMatch match = crewMatchRepository.save(CrewMatch.builder()
+                .title("다른 배틀")
+                .startAt(now.minusDays(1))
+                .endAt(now.plusDays(1))
+                .status(MatchStatus.ONGOING)
+                .build());
+
+        match.addParticipant(CrewMatchParticipant.createNew(match, otherCrew1, 0));
+        match.addParticipant(CrewMatchParticipant.createNew(match, otherCrew2, 0));
+        crewMatchRepository.save(match);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // When
+        HomeResponse response = homeService.getHome(testUser);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.battleLeague()).isNull(); // 내 크루가 참가하지 않음
+    }
+
+    @Test
+    @DisplayName("오늘 러닝 기록이 없는 경우")
+    void getHome_NoTodayRunning() {
+        // Given: 크루에 가입, 배틀 리그 참가, 하지만 오늘 러닝 기록 없음
+        crewMemberRepository.save(CrewMember.builder()
+                .crew(testCrew1)
+                .user(testUser)
+                .status(MemberStatus.APPROVED)
+                .build());
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        CrewMatch match = crewMatchRepository.save(CrewMatch.builder()
+                .title("1월 배틀")
+                .startAt(now.minusDays(1))
+                .endAt(now.plusDays(1))
+                .status(MatchStatus.ONGOING)
+                .build());
+
+        match.addParticipant(CrewMatchParticipant.createNew(match, testCrew1, 0));
+        match.addParticipant(CrewMatchParticipant.createNew(match, testCrew2, 0));
+        crewMatchRepository.save(match);
+
+        // 어제의 러닝 기록만 있음
+        runningRepository.save(Running.builder()
+                .user(testUser)
+                .crew(testCrew1)
+                .distance(5000)
+                .duration(1800)
+                .pace(360)
+                .startedAt(now.minusDays(1))
+                .build());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // When
+        HomeResponse response = homeService.getHome(testUser);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.battleLeague()).isNotNull();
+        assertThat(response.todayRunning()).isNull(); // 오늘 기록 없음
+    }
+
+    @Test
+    @DisplayName("크루 활동이 5개 이상일 때 최근 5개만 반환")
+    void getHome_RecentActivities_Limit5() {
+        // Given: 크루에 가입
+        crewMemberRepository.save(CrewMember.builder()
+                .crew(testCrew1)
+                .user(testUser)
+                .status(MemberStatus.APPROVED)
+                .build());
+
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        // 7개의 러닝 기록 생성
+        for (int i = 0; i < 7; i++) {
+            runningRepository.save(Running.builder()
+                    .user(testUser)
+                    .crew(testCrew1)
+                    .distance(1000 * (i + 1))
+                    .duration(600)
+                    .pace(360)
+                    .startedAt(now.minusHours(i))
+                    .build());
+        }
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // When
+        HomeResponse response = homeService.getHome(testUser);
+
+        // Then
+        assertThat(response.recentActivities()).hasSize(5); // 최대 5개만
+    }
+
+    @Test
+    @DisplayName("오늘 러닝 기록이 여러 개일 때 합산하여 반환")
+    void getHome_TodayRunning_SumAll() {
+        // Given: 크루에 가입
+        crewMemberRepository.save(CrewMember.builder()
+                .crew(testCrew1)
+                .user(testUser)
+                .status(MemberStatus.APPROVED)
+                .build());
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        // 오늘 정오로 설정하여 날짜 경계 문제 방지
+        LocalDateTime todayNoon = now.toLocalDate().atTime(12, 0);
+
+        // 오늘 여러 러닝 기록 생성
+        runningRepository.save(Running.builder()
+                .user(testUser)
+                .crew(testCrew1)
+                .distance(3000)
+                .duration(1200)
+                .pace(400)
+                .startedAt(todayNoon.minusHours(2))
+                .build());
+
+        runningRepository.save(Running.builder()
+                .user(testUser)
+                .crew(testCrew1)
+                .distance(5000)
+                .duration(1800)
+                .pace(360)
+                .startedAt(todayNoon.plusHours(2))
+                .build());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // When
+        HomeResponse response = homeService.getHome(testUser);
+
+        // Then
+        TodayRunningRecord todayRunning = response.todayRunning();
+        assertThat(todayRunning).isNotNull();
+        assertThat(todayRunning.distance()).isEqualTo(8000); // 3000 + 5000 합산
+        assertThat(todayRunning.duration()).isEqualTo(3000); // 1200 + 1800 합산
+        // 평균 페이스: 3000초 / (8000m / 1000) = 3000 / 8 = 375 초/km
+        assertThat(todayRunning.pace()).isEqualTo(375);
+    }
+}

--- a/src/test/java/com/example/bakersbackend/domain/match/service/CrewMatchServiceTest.java
+++ b/src/test/java/com/example/bakersbackend/domain/match/service/CrewMatchServiceTest.java
@@ -484,6 +484,13 @@ class CrewMatchServiceTest {
         assertThat(response.opponentCrewDetail().crewId()).isEqualTo(testCrew2.getId());
         assertThat(response.opponentCrewDetail().crewName()).isEqualTo("크루B");
         assertThat(response.opponentCrewDetail().totalDistance()).isEqualTo(4000);
+
+        // 내 크루는 크루원 정보 포함
+        assertThat(response.myCrewDetail().memberContributions()).isNotEmpty();
+        assertThat(response.myCrewDetail().memberContributions()).hasSize(2);
+
+        // 상대 크루는 크루원 정보 비공개
+        assertThat(response.opponentCrewDetail().memberContributions()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
- 홈화면 조회 API 구현 (GET /api/v1/home)
   
## 📌 PR 개요
 - 진행 중인 배틀 리그 요약 정보 조회
    - 오늘의 나의 러닝 기록 조회 (오늘 기록 합산)
    - 크루의 최근 활동 5개 조회 (러닝 시작 시간 기준 정렬)
  - 홈화면 서비스 테스트 작성 및 통과
## 🔧 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## 🧪 테스트 방법
- 테스트코드, 스웨거 테스트 완료

## 📎 관련 이슈
- closes #34
