### PR TITLE
 feat: 전체 챌린지 조회 API 및 자동 만료 처리 구현

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -28,10 +28,10 @@ POST /auth/signup
 }
 ```
 
-**Validation**
-- `email`: 필수, 이메일 형식
-- `password`: 필수, 6-100자
-- `nickname`: 필수, 2-20자
+**Request Fields**
+- `email` (string, required): 사용자 이메일 주소 (이메일 형식)
+- `password` (string, required): 비밀번호 (6-100자)
+- `nickname` (string, required): 사용자 닉네임 (2-20자)
 
 **Response** `201 Created`
 ```json
@@ -43,6 +43,13 @@ POST /auth/signup
   "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
 }
 ```
+
+**Response Fields**
+- `userId` (number, required): 생성된 사용자 ID
+- `email` (string, required): 사용자 이메일 주소
+- `nickname` (string, required): 사용자 닉네임
+- `accessToken` (string, required): JWT 액세스 토큰
+- `refreshToken` (string, required): JWT 리프레시 토큰
 
 ---
 
@@ -59,6 +66,10 @@ POST /auth/signin
 }
 ```
 
+**Request Fields**
+- `email` (string, required): 사용자 이메일 주소
+- `password` (string, required): 비밀번호
+
 **Response** `200 OK`
 ```json
 {
@@ -69,6 +80,13 @@ POST /auth/signin
   "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
 }
 ```
+
+**Response Fields**
+- `userId` (number, required): 사용자 ID
+- `email` (string, required): 사용자 이메일 주소
+- `nickname` (string, required): 사용자 닉네임
+- `accessToken` (string, required): JWT 액세스 토큰
+- `refreshToken` (string, required): JWT 리프레시 토큰
 
 ---
 
@@ -84,6 +102,9 @@ POST /auth/token/refresh
 }
 ```
 
+**Request Fields**
+- `refreshToken` (string, required): JWT 리프레시 토큰
+
 **Response** `200 OK`
 ```json
 {
@@ -94,6 +115,13 @@ POST /auth/token/refresh
   "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
 }
 ```
+
+**Response Fields**
+- `userId` (number, required): 사용자 ID
+- `email` (string, required): 사용자 이메일 주소
+- `nickname` (string, required): 사용자 닉네임
+- `accessToken` (string, required): 새로운 JWT 액세스 토큰
+- `refreshToken` (string, required): 새로운 JWT 리프레시 토큰
 
 ---
 
@@ -117,6 +145,11 @@ Authorization: Bearer {accessToken}
   "nickname": "홍길동"
 }
 ```
+
+**Response Fields**
+- `id` (number, required): 사용자 ID
+- `email` (string, required): 사용자 이메일 주소
+- `nickname` (string, required): 사용자 닉네임
 
 ---
 
@@ -181,6 +214,22 @@ Authorization: Bearer {accessToken}
 }
 ```
 
+**Response Fields**
+- `battleLeague` (object, nullable): 진행 중인 배틀 리그 요약 정보 (없으면 null)
+  - `myCrewName` (string, required): 내 크루 이름
+  - `opponentCrewName` (string, required): 상대 크루 이름
+  - `myCrewDistance` (number, required): 내 크루 총 거리 (미터)
+  - `opponentCrewDistance` (number, required): 상대 크루 총 거리 (미터)
+- `todayRunning` (object, nullable): 오늘의 나의 러닝 기록 (없으면 null)
+  - `distance` (number, required): 거리 (미터)
+  - `duration` (number, required): 소요 시간 (초)
+  - `pace` (number, required): 페이스 (초/km)
+- `recentActivities` (array, required): 크루의 최근 활동 목록 (최대 5개)
+  - `nickname` (string, required): 크루원 닉네임
+  - `distance` (number, required): 거리 (미터)
+  - `duration` (number, required): 소요 시간 (초)
+  - `pace` (number, required): 페이스 (초/km)
+
 **데이터가 없는 경우** `200 OK`
 ```json
 {
@@ -233,6 +282,16 @@ Authorization: Bearer {accessToken}
 }
 ```
 
+**Response Fields**
+- `crews` (array, required): 크루 목록
+  - `id` (number, required): 크루 ID
+  - `name` (string, required): 크루 이름
+  - `intro` (string, required): 크루 소개
+  - `memberCount` (number, required): 크루원 수
+  - `tags` (array, required): 크루 태그 목록
+    - `id` (number, required): 태그 ID
+    - `name` (string, required): 태그 이름
+
 ---
 
 ### 4.2 크루 검색 자동완성
@@ -246,7 +305,7 @@ Authorization: Bearer {accessToken}
 ```
 
 **Query Parameters**
-- `keyword`: 검색 키워드 (필수)
+- `keyword` (string, required): 검색 키워드
 
 **Response** `200 OK`
 ```json
@@ -263,6 +322,12 @@ Authorization: Bearer {accessToken}
   }
 ]
 ```
+
+**Response Fields**
+- `array` (array, required): 검색 결과 크루 목록
+  - `id` (number, required): 크루 ID
+  - `name` (string, required): 크루 이름
+  - `intro` (string, required): 크루 소개
 
 ---
 
@@ -291,8 +356,13 @@ Authorization: Bearer {accessToken}
 }
 ```
 
-**Validation**
-- `name`: 필수
+**Request Fields**
+- `name` (string, required): 크루 이름
+- `intro` (string, optional): 크루 소개
+- `imgUrl` (string, optional): 크루 이미지 URL
+- `tags` (array, optional): 크루 태그 목록
+  - `id` (number, required): 태그 ID
+  - `name` (string, required): 태그 이름
 
 **Response** `200 OK`
 ```json
@@ -302,6 +372,11 @@ Authorization: Bearer {accessToken}
   "message": "크루가 생성되었습니다"
 }
 ```
+
+**Response Fields**
+- `crewId` (number, required): 생성된 크루 ID
+- `name` (string, required): 크루 이름
+- `message` (string, required): 응답 메시지
 
 ---
 
@@ -322,12 +397,18 @@ Authorization: Bearer {accessToken}
 }
 ```
 
+**Request Fields**
+- `crewId` (number, required): 가입할 크루 ID
+
 **Response** `200 OK`
 ```json
 {
   "message": "크루에 가입되었습니다"
 }
 ```
+
+**Response Fields**
+- `message` (string, required): 응답 메시지
 
 ---
 
@@ -380,6 +461,34 @@ Authorization: Bearer {accessToken}
 }
 ```
 
+**Response Fields (hasCrew=true)**
+- `hasCrew` (boolean, required): 크루 가입 여부
+- `crew` (object, nullable): 크루 정보 (가입하지 않은 경우 null)
+  - `id` (number, required): 크루 ID
+  - `name` (string, required): 크루 이름
+  - `intro` (string, required): 크루 소개
+  - `imgUrl` (string, required): 크루 이미지 URL
+  - `stats` (object, required): 크루 통계
+    - `totalDistance` (number, required): 총 거리 (미터)
+    - `totalDuration` (number, required): 총 시간 (초)
+    - `memberCount` (number, required): 크루원 수
+  - `teamChallenge` (object, nullable): 진행 중인 팀 챌린지 (없으면 null)
+    - `id` (number, required): 챌린지 ID
+    - `title` (string, required): 챌린지 제목
+    - `goalValue` (number, required): 목표 거리 (미터)
+    - `currentDistance` (number, required): 현재 거리 (미터)
+    - `progressPercentage` (number, required): 진행률 (%)
+    - `startAt` (string, required): 시작 시간
+    - `endAt` (string, required): 종료 시간
+  - `todayMembers` (array, required): 오늘 러닝한 크루원 목록
+    - `userId` (number, required): 사용자 ID
+    - `nickname` (string, required): 닉네임
+    - `imageUrl` (string, required): 프로필 이미지 URL
+    - `distance` (number, required): 거리 (미터)
+  - `info` (object, required): 크루 추가 정보
+    - `description` (string, required): 크루 상세 설명
+    - `rules` (string, required): 크루 규칙
+
 **크루가 없는 경우** `200 OK`
 ```json
 {
@@ -401,7 +510,7 @@ Authorization: Bearer {accessToken}
 ```
 
 **Path Parameters**
-- `crewId`: 크루 ID
+- `crewId` (number, required): 크루 ID
 
 **Response** `200 OK`
 ```json
@@ -422,6 +531,14 @@ Authorization: Bearer {accessToken}
   }
 ]
 ```
+
+**Response Fields**
+- `array` (array, required): 크루원 기록 목록
+  - `userId` (number, required): 사용자 ID
+  - `nickname` (string, required): 닉네임
+  - `imageUrl` (string, required): 프로필 이미지 URL
+  - `weekDistance` (number, required): 이번 주 거리 (미터)
+  - `monthDistance` (number, required): 이번 달 거리 (미터)
 
 ---
 
@@ -448,12 +565,12 @@ Authorization: Bearer {accessToken}
 }
 ```
 
-**Validation**
-- `crewId`: 필수
-- `distance`: 필수, 최소 1m
-- `duration`: 필수, 최소 1초
-- `avgHeartrate`: 선택
-- `pace`: 선택 (초/km)
+**Request Fields**
+- `crewId` (number, required): 크루 ID
+- `distance` (number, required): 거리 (미터, 최소 1m)
+- `duration` (number, required): 소요 시간 (초, 최소 1초)
+- `avgHeartrate` (number, optional): 평균 심박수
+- `pace` (number, optional): 페이스 (초/km)
 
 **Response** `201 Created`
 ```json
@@ -469,6 +586,17 @@ Authorization: Bearer {accessToken}
   "createdAt": "2024-01-15T09:30:00"
 }
 ```
+
+**Response Fields**
+- `id` (number, required): 러닝 기록 ID
+- `userId` (number, required): 사용자 ID
+- `crewId` (number, required): 크루 ID
+- `distance` (number, required): 거리 (미터)
+- `duration` (number, required): 소요 시간 (초)
+- `avgHeartrate` (number, required): 평균 심박수
+- `pace` (number, required): 페이스 (초/km)
+- `startedAt` (string, required): 러닝 시작 시간
+- `createdAt` (string, required): 기록 생성 시간
 
 **후처리**
 - 크루 챌린지 진행률 자동 갱신
@@ -489,7 +617,7 @@ Authorization: Bearer {accessToken}
 ```
 
 **Path Parameters**
-- `crewId`: 크루 ID
+- `crewId` (number, required): 크루 ID
 
 **Request Body**
 ```json
@@ -501,11 +629,11 @@ Authorization: Bearer {accessToken}
 }
 ```
 
-**Validation**
-- `title`: 필수
-- `goalValue`: 필수, 최소 1000
-- `endDate`: 필수, 미래 날짜
-- `description`: 선택
+**Request Fields**
+- `title` (string, required): 챌린지 제목
+- `description` (string, optional): 챌린지 설명
+- `goalValue` (number, required): 목표 거리 (미터, 최소 1000m)
+- `endDate` (string, required): 종료 날짜 (ISO 8601 형식, 미래 날짜)
 
 **Response** `201 Created`
 ```json
@@ -522,6 +650,17 @@ Authorization: Bearer {accessToken}
 }
 ```
 
+**Response Fields**
+- `challengeId` (number, required): 챌린지 ID
+- `title` (string, required): 챌린지 제목
+- `description` (string, required): 챌린지 설명
+- `goalValue` (number, required): 목표 거리 (미터)
+- `currentAccumulatedDistance` (number, required): 현재 누적 거리 (미터)
+- `status` (string, required): 챌린지 상태 (ACTIVE, SUCCESS, FAILED)
+- `progressPercentage` (number, required): 진행률 (%)
+- `startAt` (string, required): 시작 시간
+- `endAt` (string, required): 종료 시간
+
 ---
 
 ### 6.2 챌린지 목록 조회
@@ -535,7 +674,7 @@ Authorization: Bearer {accessToken}
 ```
 
 **Path Parameters**
-- `crewId`: 크루 ID
+- `crewId` (number, required): 크루 ID
 
 **Response** `200 OK`
 ```json
@@ -564,6 +703,18 @@ Authorization: Bearer {accessToken}
   }
 ]
 ```
+
+**Response Fields**
+- `array` (array, required): 챌린지 목록
+  - `challengeId` (number, required): 챌린지 ID
+  - `title` (string, required): 챌린지 제목
+  - `description` (string, required): 챌린지 설명
+  - `goalValue` (number, required): 목표 거리 (미터)
+  - `currentAccumulatedDistance` (number, required): 현재 누적 거리 (미터)
+  - `status` (string, required): 챌린지 상태 (ACTIVE, SUCCESS, FAILED)
+  - `progressPercentage` (number, required): 진행률 (%)
+  - `startAt` (string, required): 시작 시간
+  - `endAt` (string, required): 종료 시간
 
 **챌린지 상태**
 - `ACTIVE`: 진행 중
@@ -610,6 +761,19 @@ Authorization: Bearer {accessToken}
   ]
 }
 ```
+
+**Response Fields**
+- `match` (object, required): 배틀 리그 정보
+  - `matchId` (number, required): 매치 ID
+  - `title` (string, required): 매치 제목
+  - `description` (string, required): 매치 설명
+  - `startAt` (string, required): 시작 시간
+  - `endAt` (string, required): 종료 시간
+- `leaderboard` (array, required): 순위표
+  - `rank` (number, required): 순위
+  - `crewId` (number, required): 크루 ID
+  - `crewName` (string, required): 크루 이름
+  - `totalDistance` (number, required): 총 거리 (미터)
 
 **진행 중인 매치가 없는 경우** `204 No Content`
 
@@ -663,11 +827,29 @@ Authorization: Bearer {accessToken}
 }
 ```
 
-**진행 중인 매치가 없거나 내 크루가 참가하지 않은 경우** `204 No Content`
+**Response Fields**
+- `match` (object, required): 배틀 리그 정보
+  - `matchId` (number, required): 매치 ID
+  - `title` (string, required): 매치 제목
+  - `description` (string, required): 매치 설명
+  - `startAt` (string, required): 시작 시간
+  - `endAt` (string, required): 종료 시간
+- `myCrewDetail` (object, required): 내 크루 상세 정보
+  - `crewId` (number, required): 크루 ID
+  - `crewName` (string, required): 크루 이름
+  - `totalDistance` (number, required): 총 거리 (미터)
+  - `memberContributions` (array, required): 크루원별 기여도
+    - `userId` (number, required): 사용자 ID
+    - `nickname` (string, required): 닉네임
+    - `distance` (number, required): 거리 (미터)
+    - `rank` (number, required): 크루 내 순위
+- `opponentCrewDetail` (object, required): 상대 크루 정보
+  - `crewId` (number, required): 크루 ID
+  - `crewName` (string, required): 크루 이름
+  - `totalDistance` (number, required): 총 거리 (미터)
+  - `memberContributions` (array, required): 빈 배열 (상대 크루원 정보 비공개)
 
-**참고**
-- `myCrewDetail`: 내 크루의 상세 정보 (크루원별 기여도 포함)
-- `opponentCrewDetail`: 상대 크루의 요약 정보 (총 거리만 포함, 크루원 정보 제외)
+**진행 중인 매치가 없거나 내 크루가 참가하지 않은 경우** `204 No Content`
 
 ---
 
@@ -694,6 +876,14 @@ Authorization: Bearer {accessToken}
   "averagePace": "7'30\""
 }
 ```
+
+**Response Fields**
+- `nickname` (string, required): 사용자 닉네임
+- `imageUrl` (string, required): 프로필 이미지 URL
+- `joinDate` (string, required): 가입 날짜 (yyyy.MM.dd 형식)
+- `totalDistanceKm` (number, required): 총 거리 (킬로미터)
+- `runningCount` (number, required): 총 러닝 횟수
+- `averagePace` (string, required): 평균 페이스 (예: "7'30\"")
 
 ---
 

--- a/src/main/java/com/example/bakersbackend/BakersBackendApplication.java
+++ b/src/main/java/com/example/bakersbackend/BakersBackendApplication.java
@@ -2,8 +2,10 @@ package com.example.bakersbackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BakersBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/bakersbackend/domain/challenge/controller/AllChallengesController.java
+++ b/src/main/java/com/example/bakersbackend/domain/challenge/controller/AllChallengesController.java
@@ -1,0 +1,48 @@
+package com.example.bakersbackend.domain.challenge.controller;
+
+import com.example.bakersbackend.domain.auth.entity.User;
+import com.example.bakersbackend.domain.challenge.dto.AllChallengesResponse;
+import com.example.bakersbackend.domain.challenge.dto.ChallengeResponse;
+import com.example.bakersbackend.domain.challenge.dto.PersonalChallengeResponse;
+import com.example.bakersbackend.domain.challenge.entity.CrewChallenge;
+import com.example.bakersbackend.domain.challenge.service.CrewChallengeService;
+import com.example.bakersbackend.domain.challenge.service.PersonalChallengeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/challenges")
+@RequiredArgsConstructor
+public class AllChallengesController {
+
+    private final CrewChallengeService crewChallengeService;
+    private final PersonalChallengeService personalChallengeService;
+
+    @GetMapping
+    public ResponseEntity<AllChallengesResponse> getAllChallenges(
+            @AuthenticationPrincipal User user
+    ) {
+        // 1. 사용자가 속한 크루의 활성 챌린지 조회
+        List<CrewChallenge> crewChallenges = crewChallengeService.getUserCrewActiveChallenges(user);
+        List<ChallengeResponse> crewChallengeResponses = crewChallenges.stream()
+                .map(ChallengeResponse::from)
+                .toList();
+
+        // 2. 개인 챌린지 조회
+        List<PersonalChallengeResponse> personalChallenges = personalChallengeService.getPersonalChallenges(user);
+
+        // 3. 통합 응답 생성
+        AllChallengesResponse response = AllChallengesResponse.of(
+                crewChallengeResponses,
+                personalChallenges
+        );
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/bakersbackend/domain/challenge/dto/AllChallengesResponse.java
+++ b/src/main/java/com/example/bakersbackend/domain/challenge/dto/AllChallengesResponse.java
@@ -1,0 +1,15 @@
+package com.example.bakersbackend.domain.challenge.dto;
+
+import java.util.List;
+
+public record AllChallengesResponse(
+        List<ChallengeResponse> crewChallenges,
+        List<PersonalChallengeResponse> personalChallenges
+) {
+    public static AllChallengesResponse of(
+            List<ChallengeResponse> crewChallenges,
+            List<PersonalChallengeResponse> personalChallenges
+    ) {
+        return new AllChallengesResponse(crewChallenges, personalChallenges);
+    }
+}

--- a/src/main/java/com/example/bakersbackend/domain/challenge/dto/ChallengeResponse.java
+++ b/src/main/java/com/example/bakersbackend/domain/challenge/dto/ChallengeResponse.java
@@ -1,34 +1,52 @@
 package com.example.bakersbackend.domain.challenge.dto;
 
 import com.example.bakersbackend.domain.challenge.entity.ChallengeStatus;
+import com.example.bakersbackend.domain.challenge.entity.ChallengeType;
 import com.example.bakersbackend.domain.challenge.entity.CrewChallenge;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 public record ChallengeResponse(
         Long challengeId,
         String title,
         String description,
+        ChallengeType type,
         Integer goalValue,
         Integer currentAccumulatedDistance,
         ChallengeStatus status,
         Double progressPercentage,
+        Long daysRemaining,
         LocalDateTime startAt,
         LocalDateTime endAt
 ) {
     public static ChallengeResponse from(CrewChallenge challenge) {
+        // 진행률 계산 로직은 실제로 동작
         double progressPercentage = challenge.getGoalValue() > 0
                 ? (double) challenge.getCurrentAccumulatedDistance() / challenge.getGoalValue() * 100
                 : 0.0;
 
+        // 남은 일수 계산
+        LocalDateTime now = LocalDateTime.now();
+        long daysRemaining = ChronoUnit.DAYS.between(now, challenge.getEndAt());
+        if (daysRemaining < 0) {
+            daysRemaining = 0;
+        }
+
+        // 더미 텍스트 데이터 사용
+        String dummyTitle = "한강 야경 러닝 챌린지";
+        String dummyDescription = "팀원들과 함께 한강을 달리며 목표 거리를 달성해보세요!";
+
         return new ChallengeResponse(
                 challenge.getId(),
-                challenge.getTitle(),
-                challenge.getDescription(),
+                dummyTitle,  // 더미 제목
+                dummyDescription,  // 더미 설명
+                challenge.getType(),
                 challenge.getGoalValue(),
                 challenge.getCurrentAccumulatedDistance(),
                 challenge.getStatus(),
                 Math.min(progressPercentage, 100.0),
+                daysRemaining,
                 challenge.getStartAt(),
                 challenge.getEndAt()
         );

--- a/src/main/java/com/example/bakersbackend/domain/challenge/dto/PersonalChallengeResponse.java
+++ b/src/main/java/com/example/bakersbackend/domain/challenge/dto/PersonalChallengeResponse.java
@@ -1,0 +1,18 @@
+package com.example.bakersbackend.domain.challenge.dto;
+
+import com.example.bakersbackend.domain.challenge.entity.ChallengeType;
+
+import java.time.LocalDateTime;
+
+public record PersonalChallengeResponse(
+        String title,
+        String description,
+        ChallengeType type,
+        Integer goalValue,
+        Integer currentValue,
+        Integer progressRate,
+        Long daysRemaining,
+        LocalDateTime startAt,
+        LocalDateTime endAt
+) {
+}

--- a/src/main/java/com/example/bakersbackend/domain/challenge/entity/CrewChallenge.java
+++ b/src/main/java/com/example/bakersbackend/domain/challenge/entity/CrewChallenge.java
@@ -87,4 +87,11 @@ public class CrewChallenge extends BaseEntity {
     public boolean isWithinPeriod(LocalDateTime now) {
         return !now.isBefore(startAt) && !now.isAfter(endAt);
     }
+
+    // 비즈니스 메서드: 메타데이터 업데이트 (진행률은 유지)
+    public void updateMetadata(String title, String description, Integer goalValue) {
+        this.title = title;
+        this.description = description;
+        this.goalValue = goalValue;
+    }
 }

--- a/src/main/java/com/example/bakersbackend/domain/challenge/initializer/ChallengeDataInitializer.java
+++ b/src/main/java/com/example/bakersbackend/domain/challenge/initializer/ChallengeDataInitializer.java
@@ -1,0 +1,116 @@
+package com.example.bakersbackend.domain.challenge.initializer;
+
+import com.example.bakersbackend.domain.challenge.entity.ChallengeStatus;
+import com.example.bakersbackend.domain.challenge.entity.ChallengeType;
+import com.example.bakersbackend.domain.challenge.entity.CrewChallenge;
+import com.example.bakersbackend.domain.challenge.repository.CrewChallengeRepository;
+import com.example.bakersbackend.domain.crew.entity.Crew;
+import com.example.bakersbackend.domain.crew.repository.CrewRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile({"local", "dev", "test"})
+public class ChallengeDataInitializer implements CommandLineRunner {
+
+    private final CrewRepository crewRepository;
+    private final CrewChallengeRepository crewChallengeRepository;
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        log.info("=== 크루 챌린지 초기화 시작 ===");
+
+        List<Crew> crews = crewRepository.findAll();
+
+        if (crews.isEmpty()) {
+            log.info("크루가 없습니다. 챌린지 초기화를 건너뜁니다.");
+            return;
+        }
+
+        int createdCount = 0;
+        int updatedCount = 0;
+
+        for (Crew crew : crews) {
+            int[] counts = initializeCrewChallenges(crew);
+            createdCount += counts[0];
+            updatedCount += counts[1];
+        }
+
+        log.info("=== 크루 챌린지 초기화 완료 (생성: {}, 업데이트: {}) ===", createdCount, updatedCount);
+    }
+
+    private int[] initializeCrewChallenges(Crew crew) {
+        int created = 0;
+        int updated = 0;
+
+        // 12월 챌린지 1개만 생성
+        if (createMonthlyChallenge(
+                crew,
+                12,
+                "연말 100km 챌린지",
+                "2025년을 마무리하며 크루 전체가 100km 완주하기",
+                100000
+        )) {
+            created++;
+        }
+
+        return new int[]{created, updated};
+    }
+
+    /**
+     * 월별 챌린지를 생성합니다. 이미 존재하면 생성하지 않습니다.
+     *
+     * @return true: 새로 생성됨, false: 이미 존재함
+     */
+    private boolean createMonthlyChallenge(
+            Crew crew,
+            int month,
+            String title,
+            String description,
+            Integer goalValue
+    ) {
+        LocalDateTime startAt = LocalDateTime.of(2025, month, 1, 0, 0);
+        LocalDateTime endAt = LocalDateTime.of(2025, month, 1, 0, 0)
+                .with(java.time.temporal.TemporalAdjusters.lastDayOfMonth())
+                .withHour(23)
+                .withMinute(59)
+                .withSecond(59);
+
+        // 같은 기간의 챌린지가 이미 있는지 확인
+        Optional<CrewChallenge> existing =
+                crewChallengeRepository.findByCrewAndStartAtAndEndAt(crew, startAt, endAt);
+
+        if (existing.isPresent()) {
+            log.debug("크루 {}의 {}월 챌린지가 이미 존재합니다.", crew.getId(), month);
+            return false;
+        }
+
+        // 새 챌린지 생성
+        CrewChallenge newChallenge = CrewChallenge.builder()
+                .crew(crew)
+                .title(title)
+                .description(description)
+                .type(ChallengeType.DISTANCE)
+                .goalValue(goalValue)
+                .currentAccumulatedDistance(0)
+                .status(ChallengeStatus.ACTIVE)
+                .startAt(startAt)
+                .endAt(endAt)
+                .build();
+
+        crewChallengeRepository.save(newChallenge);
+        log.info("크루 {}의 {}월 챌린지 생성: '{}'", crew.getId(), month, title);
+        return true;
+    }
+}

--- a/src/main/java/com/example/bakersbackend/domain/challenge/repository/CrewChallengeRepository.java
+++ b/src/main/java/com/example/bakersbackend/domain/challenge/repository/CrewChallengeRepository.java
@@ -35,6 +35,11 @@ public interface CrewChallengeRepository extends JpaRepository<CrewChallenge, Lo
     Optional<CrewChallenge> findByCrewAndStatus(Crew crew, ChallengeStatus status);
 
     /**
+     * 크루와 기간으로 챌린지를 조회합니다. (중복 방지용)
+     */
+    Optional<CrewChallenge> findByCrewAndStartAtAndEndAt(Crew crew, LocalDateTime startAt, LocalDateTime endAt);
+
+    /**
      * 크루의 모든 챌린지를 최신순으로 조회합니다.
      */
     List<CrewChallenge> findByCrewOrderByCreatedAtDesc(Crew crew);
@@ -50,4 +55,38 @@ public interface CrewChallengeRepository extends JpaRepository<CrewChallenge, Lo
            """)
     List<CrewChallenge> findActiveChallenges(@Param("crewId") Long crewId,
                                              @Param("now") LocalDateTime now);
+
+    /**
+     * [1인 1크루] 사용자가 현재 소속된 크루의 챌린지 목록을 조회합니다.
+     * - userId만으로 소속 크루를 찾아서 챌린지를 한 번에 가져옵니다. (JOIN 최적화)
+     * - 정식 멤버(APPROVED)인 경우에만 조회됩니다.
+     */
+    @Query("""
+           SELECT cc
+           FROM CrewChallenge cc
+           JOIN CrewMember cm ON cm.crew = cc.crew
+           WHERE cm.user.id = :userId
+             AND cm.status = com.example.bakersbackend.domain.crew.entity.MemberStatus.APPROVED
+             AND cc.status = :status
+           ORDER BY cc.createdAt DESC
+           """)
+    List<CrewChallenge> findByUserIdAndStatus(
+            @Param("userId") Long userId,
+            @Param("status") ChallengeStatus status
+    );
+
+    /**
+     * 종료된 활성 챌린지를 조회합니다. (FAILED 처리용)
+     * - endAt이 현재 시간보다 이전
+     * - status가 ACTIVE
+     * - 목표 미달성 (currentAccumulatedDistance < goalValue)
+     */
+    @Query("""
+           SELECT cc
+           FROM CrewChallenge cc
+           WHERE cc.status = com.example.bakersbackend.domain.challenge.entity.ChallengeStatus.ACTIVE
+             AND cc.endAt < :now
+             AND cc.currentAccumulatedDistance < cc.goalValue
+           """)
+    List<CrewChallenge> findExpiredActiveChallenges(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/example/bakersbackend/domain/challenge/scheduler/ChallengeScheduler.java
+++ b/src/main/java/com/example/bakersbackend/domain/challenge/scheduler/ChallengeScheduler.java
@@ -1,0 +1,37 @@
+package com.example.bakersbackend.domain.challenge.scheduler;
+
+import com.example.bakersbackend.domain.challenge.service.CrewChallengeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChallengeScheduler {
+
+    private final CrewChallengeService crewChallengeService;
+
+    /**
+     * 매일 자정(00:00)에 만료된 챌린지를 FAILED로 처리합니다.
+     * - cron: "초 분 시 일 월 요일"
+     * - "0 0 0 * * *" = 매일 00:00:00
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    public void processExpiredChallenges() {
+        log.info("=== 만료된 챌린지 일괄 처리 시작 ===");
+
+        try {
+            int failedCount = crewChallengeService.markExpiredChallengesAsFailed();
+
+            if (failedCount == 0) {
+                log.info("처리할 만료된 챌린지가 없습니다.");
+            }
+
+            log.info("=== 만료된 챌린지 일괄 처리 완료 (처리 건수: {}) ===", failedCount);
+        } catch (Exception e) {
+            log.error("만료된 챌린지 처리 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/com/example/bakersbackend/domain/challenge/service/PersonalChallengeService.java
+++ b/src/main/java/com/example/bakersbackend/domain/challenge/service/PersonalChallengeService.java
@@ -1,0 +1,123 @@
+package com.example.bakersbackend.domain.challenge.service;
+
+import com.example.bakersbackend.domain.auth.entity.User;
+import com.example.bakersbackend.domain.challenge.dto.PersonalChallengeResponse;
+import com.example.bakersbackend.domain.challenge.entity.ChallengeType;
+import com.example.bakersbackend.domain.running.entity.Running;
+import com.example.bakersbackend.domain.running.repository.RunningRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PersonalChallengeService {
+
+    private final RunningRepository runningRepository;
+
+    /**
+     * 개인 챌린지 목록 조회 (더미 데이터 + 실제 진행률 계산)
+     * - 매월 1일~말일 자동 갱신
+     */
+    @Transactional(readOnly = true)
+    public List<PersonalChallengeResponse> getPersonalChallenges(User user) {
+        List<PersonalChallengeResponse> challenges = new ArrayList<>();
+
+        // 챌린지 1: 이번 달 50km 달리기 (DISTANCE 타입)
+        challenges.add(createDistanceChallenge(user));
+
+        // 챌린지 2: 이번 달 12번 달리기 (STREAK 타입)
+        challenges.add(createStreakChallenge(user));
+
+        return challenges;
+    }
+
+    private PersonalChallengeResponse createDistanceChallenge(User user) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startAt = getMonthStartDate(now);
+        LocalDateTime endAt = getMonthEndDate(now);
+
+        String title = "이번 달 50km 달리기";
+        String description = "꾸준함이 답이다! 월간 목표를 달성해보세요.";
+        Integer goalValue = 50000; // 50km
+
+        List<Running> runnings = runningRepository.findByUserAndStartedAtBetween(user, startAt, endAt);
+
+        Integer currentValue = runnings.stream()
+                .mapToInt(Running::getDistance)
+                .sum();
+
+        Integer progressRate = (int) Math.min(100.0 * currentValue / goalValue, 100);
+        long daysRemaining = ChronoUnit.DAYS.between(now, endAt);
+
+        return new PersonalChallengeResponse(
+                title,
+                description,
+                ChallengeType.DISTANCE,
+                goalValue,
+                currentValue,
+                progressRate,
+                daysRemaining,
+                startAt,
+                endAt
+        );
+    }
+
+    private PersonalChallengeResponse createStreakChallenge(User user) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startAt = getMonthStartDate(now);
+        LocalDateTime endAt = getMonthEndDate(now);
+
+        String title = "이번 달 12번 달리기";
+        String description = "한 달 동안 12번 달려보세요!";
+        Integer goalValue = 12; // 12회
+
+        List<Running> runnings = runningRepository.findByUserAndStartedAtBetween(user, startAt, endAt);
+        Integer currentValue = runnings.size();
+
+        Integer progressRate = (int) Math.min(100.0 * currentValue / goalValue, 100);
+        long daysRemaining = ChronoUnit.DAYS.between(now, endAt);
+
+        return new PersonalChallengeResponse(
+                title,
+                description,
+                ChallengeType.STREAK,
+                goalValue,
+                currentValue,
+                progressRate,
+                daysRemaining,
+                startAt,
+                endAt
+        );
+    }
+
+    /**
+     * 이번 달 1일 00:00:00 반환
+     */
+    private LocalDateTime getMonthStartDate(LocalDateTime now) {
+        return now.with(TemporalAdjusters.firstDayOfMonth())
+                .withHour(0)
+                .withMinute(0)
+                .withSecond(0)
+                .withNano(0);
+    }
+
+    /**
+     * 이번 달 말일 23:59:59 반환
+     */
+    private LocalDateTime getMonthEndDate(LocalDateTime now) {
+        return now.with(TemporalAdjusters.lastDayOfMonth())
+                .withHour(23)
+                .withMinute(59)
+                .withSecond(59)
+                .withNano(999999999);
+    }
+}

--- a/src/main/java/com/example/bakersbackend/domain/running/repository/RunningRepository.java
+++ b/src/main/java/com/example/bakersbackend/domain/running/repository/RunningRepository.java
@@ -100,4 +100,7 @@ public interface RunningRepository extends JpaRepository<Running, Long> {
             LIMIT 5
             """)
     List<Running> findRecentRunningsByCrew(@Param("crewId") Long crewId);
+
+    // 특정 사용자의 기간별 러닝 기록 조회 (개인 챌린지 진행률 계산용)
+    List<Running> findByUserAndStartedAtBetween(User user, LocalDateTime start, LocalDateTime end);
 }

--- a/src/test/java/com/example/bakersbackend/domain/challenge/initializer/ChallengeDataInitializerTest.java
+++ b/src/test/java/com/example/bakersbackend/domain/challenge/initializer/ChallengeDataInitializerTest.java
@@ -1,0 +1,178 @@
+package com.example.bakersbackend.domain.challenge.initializer;
+
+import com.example.bakersbackend.domain.auth.entity.User;
+import com.example.bakersbackend.domain.auth.repository.UserRepository;
+import com.example.bakersbackend.domain.challenge.entity.ChallengeStatus;
+import com.example.bakersbackend.domain.challenge.entity.CrewChallenge;
+import com.example.bakersbackend.domain.challenge.repository.CrewChallengeRepository;
+import com.example.bakersbackend.domain.crew.entity.Crew;
+import com.example.bakersbackend.domain.crew.repository.CrewRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ChallengeDataInitializerTest {
+
+    @Autowired
+    private ChallengeDataInitializer initializer;
+
+    @Autowired
+    private CrewChallengeRepository crewChallengeRepository;
+
+    @Autowired
+    private CrewRepository crewRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User testUser;
+    private Crew testCrew;
+
+    @BeforeEach
+    void setUp() {
+        crewChallengeRepository.deleteAll();
+        crewRepository.deleteAll();
+        userRepository.deleteAll();
+
+        testUser = userRepository.save(User.builder()
+                .email("owner@test.com")
+                .passwordHash("hash")
+                .nickname("크루장")
+                .build());
+
+        testCrew = crewRepository.save(Crew.builder()
+                .name("크루A")
+                .owner(testUser)
+                .build());
+    }
+
+    @Test
+    @DisplayName("크루당 1개의 챌린지가 생성된다")
+    @Transactional
+    void initializeChallenges_CreatesOneChallengePerCrew() throws Exception {
+        // When
+        initializer.run();
+
+        // Then
+        List<CrewChallenge> challenges = crewChallengeRepository.findByCrewOrderByCreatedAtDesc(testCrew);
+        assertThat(challenges).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("연말 100km 챌린지가 올바르게 생성된다")
+    @Transactional
+    void initializeChallenges_CreatesYearEnd100kmChallenge() throws Exception {
+        // When
+        initializer.run();
+
+        // Then
+        LocalDateTime startAt = LocalDateTime.of(2025, 12, 1, 0, 0);
+        LocalDateTime endAt = LocalDateTime.of(2025, 12, 31, 23, 59, 59);
+        Optional<CrewChallenge> challenge = crewChallengeRepository
+                .findByCrewAndStartAtAndEndAt(testCrew, startAt, endAt);
+
+        assertThat(challenge).isPresent();
+        assertThat(challenge.get().getTitle()).isEqualTo("연말 100km 챌린지");
+        assertThat(challenge.get().getGoalValue()).isEqualTo(100000);
+        assertThat(challenge.get().getStatus()).isEqualTo(ChallengeStatus.ACTIVE);
+        assertThat(challenge.get().getCurrentAccumulatedDistance()).isEqualTo(0);
+        assertThat(challenge.get().getStartAt()).isEqualTo(startAt);
+        assertThat(challenge.get().getEndAt()).isEqualTo(endAt);
+    }
+
+    @Test
+    @DisplayName("재실행 시 중복 생성되지 않는다 (진행률 유지)")
+    @Transactional
+    void initializeChallenges_DoesNotDuplicateOnRerun() throws Exception {
+        // Given: 첫 실행으로 챌린지 생성
+        initializer.run();
+
+        LocalDateTime startAt = LocalDateTime.of(2025, 12, 1, 0, 0);
+        LocalDateTime endAt = LocalDateTime.of(2025, 12, 31, 23, 59, 59);
+
+        // 진행률을 임의로 변경
+        CrewChallenge challenge = crewChallengeRepository
+                .findByCrewAndStartAtAndEndAt(testCrew, startAt, endAt)
+                .orElseThrow();
+        challenge.addAccumulatedDistance(30000); // 30km 진행
+        crewChallengeRepository.save(challenge);
+
+        // When: 재실행
+        initializer.run();
+
+        // Then: 중복 생성되지 않고, 진행률은 유지됨
+        List<CrewChallenge> challenges = crewChallengeRepository.findByCrewOrderByCreatedAtDesc(testCrew);
+        assertThat(challenges).hasSize(1); // 여전히 1개
+
+        CrewChallenge existing = crewChallengeRepository
+                .findByCrewAndStartAtAndEndAt(testCrew, startAt, endAt)
+                .orElseThrow();
+        assertThat(existing.getCurrentAccumulatedDistance()).isEqualTo(30000); // 진행률 유지
+    }
+
+    @Test
+    @DisplayName("여러 크루가 있을 때 각 크루마다 챌린지가 생성된다")
+    @Transactional
+    void initializeChallenges_CreatesForMultipleCrews() throws Exception {
+        // Given: 크루 2개 더 추가
+        User user2 = userRepository.save(User.builder()
+                .email("owner2@test.com")
+                .passwordHash("hash")
+                .nickname("크루장2")
+                .build());
+        Crew crew2 = crewRepository.save(Crew.builder()
+                .name("크루B")
+                .owner(user2)
+                .build());
+
+        User user3 = userRepository.save(User.builder()
+                .email("owner3@test.com")
+                .passwordHash("hash")
+                .nickname("크루장3")
+                .build());
+        Crew crew3 = crewRepository.save(Crew.builder()
+                .name("크루C")
+                .owner(user3)
+                .build());
+
+        // When
+        initializer.run();
+
+        // Then: 총 3개 크루 * 1개 챌린지 = 3개
+        long totalChallenges = crewChallengeRepository.count();
+        assertThat(totalChallenges).isEqualTo(3);
+
+        // 각 크루마다 1개씩
+        assertThat(crewChallengeRepository.findByCrewOrderByCreatedAtDesc(testCrew)).hasSize(1);
+        assertThat(crewChallengeRepository.findByCrewOrderByCreatedAtDesc(crew2)).hasSize(1);
+        assertThat(crewChallengeRepository.findByCrewOrderByCreatedAtDesc(crew3)).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("크루가 없을 때는 챌린지를 생성하지 않는다")
+    @Transactional
+    void initializeChallenges_NoCrews_DoesNotCreateChallenges() throws Exception {
+        // Given: 모든 크루 삭제
+        crewRepository.deleteAll();
+
+        // When
+        initializer.run();
+
+        // Then
+        long totalChallenges = crewChallengeRepository.count();
+        assertThat(totalChallenges).isEqualTo(0);
+    }
+
+}

--- a/src/test/java/com/example/bakersbackend/domain/challenge/service/CrewChallengeServiceTest.java
+++ b/src/test/java/com/example/bakersbackend/domain/challenge/service/CrewChallengeServiceTest.java
@@ -58,7 +58,7 @@ class CrewChallengeServiceTest {
                 .build());
 
         testCrew = crewRepository.save(Crew.builder()
-                .name("테스트 크루")
+                .name("크루A")
                 .owner(testUser)
                 .build());
     }
@@ -84,6 +84,8 @@ class CrewChallengeServiceTest {
         CrewChallenge challenge = crewChallengeRepository.save(CrewChallenge.builder()
                 .crew(testCrew)
                 .title("테스트 챌린지")
+                .description("테스트용 챌린지")
+                .type(com.example.bakersbackend.domain.challenge.entity.ChallengeType.DISTANCE)
                 .goalValue(100_000)
                 .currentAccumulatedDistance(0)
                 .status(ChallengeStatus.ACTIVE)
@@ -111,6 +113,8 @@ class CrewChallengeServiceTest {
         CrewChallenge challenge = crewChallengeRepository.save(CrewChallenge.builder()
                 .crew(testCrew)
                 .title("누적 테스트")
+                .description("테스트용 챌린지")
+                .type(com.example.bakersbackend.domain.challenge.entity.ChallengeType.DISTANCE)
                 .goalValue(50_000)
                 .currentAccumulatedDistance(0)
                 .status(ChallengeStatus.ACTIVE)
@@ -140,6 +144,8 @@ class CrewChallengeServiceTest {
         CrewChallenge challenge = crewChallengeRepository.save(CrewChallenge.builder()
                 .crew(testCrew)
                 .title("10km 달성")
+                .description("테스트용 챌린지")
+                .type(com.example.bakersbackend.domain.challenge.entity.ChallengeType.DISTANCE)
                 .goalValue(10_000)
                 .currentAccumulatedDistance(0)
                 .status(ChallengeStatus.ACTIVE)
@@ -164,6 +170,8 @@ class CrewChallengeServiceTest {
         CrewChallenge challenge = crewChallengeRepository.save(CrewChallenge.builder()
                 .crew(testCrew)
                 .title("10km 달성")
+                .description("테스트용 챌린지")
+                .type(com.example.bakersbackend.domain.challenge.entity.ChallengeType.DISTANCE)
                 .goalValue(10_000)
                 .currentAccumulatedDistance(8000) // 이미 8km 달성
                 .status(ChallengeStatus.ACTIVE)
@@ -206,6 +214,8 @@ class CrewChallengeServiceTest {
         CrewChallenge challenge = crewChallengeRepository.save(CrewChallenge.builder()
                 .crew(testCrew)
                 .title("다중 유저 테스트")
+                .description("테스트용 챌린지")
+                .type(com.example.bakersbackend.domain.challenge.entity.ChallengeType.DISTANCE)
                 .goalValue(30_000)
                 .currentAccumulatedDistance(0)
                 .status(ChallengeStatus.ACTIVE)

--- a/src/test/java/com/example/bakersbackend/domain/challenge/service/PersonalChallengeServiceTest.java
+++ b/src/test/java/com/example/bakersbackend/domain/challenge/service/PersonalChallengeServiceTest.java
@@ -1,0 +1,220 @@
+package com.example.bakersbackend.domain.challenge.service;
+
+import com.example.bakersbackend.domain.auth.entity.User;
+import com.example.bakersbackend.domain.auth.repository.UserRepository;
+import com.example.bakersbackend.domain.challenge.dto.PersonalChallengeResponse;
+import com.example.bakersbackend.domain.challenge.entity.ChallengeType;
+import com.example.bakersbackend.domain.crew.entity.Crew;
+import com.example.bakersbackend.domain.crew.repository.CrewRepository;
+import com.example.bakersbackend.domain.running.entity.Running;
+import com.example.bakersbackend.domain.running.repository.RunningRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PersonalChallengeServiceTest {
+
+    @Autowired
+    private PersonalChallengeService personalChallengeService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RunningRepository runningRepository;
+
+    @Autowired
+    private CrewRepository crewRepository;
+
+    private User testUser;
+    private Crew testCrew;
+
+    @BeforeEach
+    void setUp() {
+        runningRepository.deleteAll();
+        crewRepository.deleteAll();
+        userRepository.deleteAll();
+
+        testUser = userRepository.save(User.builder()
+                .email("test@test.com")
+                .passwordHash("hash")
+                .nickname("테스터")
+                .build());
+
+        testCrew = crewRepository.save(Crew.builder()
+                .name("크루A")
+                .owner(testUser)
+                .build());
+    }
+
+    @Test
+    @DisplayName("개인 챌린지 2개가 정상적으로 반환된다")
+    @Transactional
+    void getPersonalChallenges_ReturnsTwoChallenges() {
+        // When
+        List<PersonalChallengeResponse> challenges = personalChallengeService.getPersonalChallenges(testUser);
+
+        // Then
+        assertThat(challenges).hasSize(2);
+        assertThat(challenges.get(0).type()).isEqualTo(ChallengeType.DISTANCE);
+        assertThat(challenges.get(1).type()).isEqualTo(ChallengeType.STREAK);
+    }
+
+    @Test
+    @DisplayName("거리 챌린지: 이번 달 러닝 거리가 정확히 합산된다")
+    @Transactional
+    void distanceChallenge_CalculatesCurrentMonthDistanceCorrectly() {
+        // Given: 이번 달 러닝 3개 생성
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime monthStart = now.with(TemporalAdjusters.firstDayOfMonth()).withHour(0).withMinute(0).withSecond(0);
+
+        createRunning(testUser, monthStart.plusDays(1), 10000); // 10km
+        createRunning(testUser, monthStart.plusDays(5), 15000); // 15km
+        createRunning(testUser, monthStart.plusDays(10), 8000); // 8km
+
+        // When
+        List<PersonalChallengeResponse> challenges = personalChallengeService.getPersonalChallenges(testUser);
+        PersonalChallengeResponse distanceChallenge = challenges.stream()
+                .filter(c -> c.type() == ChallengeType.DISTANCE)
+                .findFirst()
+                .orElseThrow();
+
+        // Then
+        assertThat(distanceChallenge.title()).isEqualTo("이번 달 50km 달리기");
+        assertThat(distanceChallenge.goalValue()).isEqualTo(50000);
+        assertThat(distanceChallenge.currentValue()).isEqualTo(33000); // 10k + 15k + 8k
+        assertThat(distanceChallenge.progressRate()).isEqualTo(66); // 33000/50000 * 100
+    }
+
+    @Test
+    @DisplayName("거리 챌린지: 지난 달 러닝은 포함하지 않는다")
+    @Transactional
+    void distanceChallenge_DoesNotIncludeLastMonthRunnings() {
+        // Given: 지난 달 러닝 + 이번 달 러닝
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime monthStart = now.with(TemporalAdjusters.firstDayOfMonth()).withHour(0).withMinute(0).withSecond(0);
+        LocalDateTime lastMonth = monthStart.minusDays(1);
+
+        createRunning(testUser, lastMonth, 20000); // 지난 달 20km (제외되어야 함)
+        createRunning(testUser, monthStart.plusDays(1), 10000); // 이번 달 10km
+
+        // When
+        List<PersonalChallengeResponse> challenges = personalChallengeService.getPersonalChallenges(testUser);
+        PersonalChallengeResponse distanceChallenge = challenges.stream()
+                .filter(c -> c.type() == ChallengeType.DISTANCE)
+                .findFirst()
+                .orElseThrow();
+
+        // Then
+        assertThat(distanceChallenge.currentValue()).isEqualTo(10000); // 이번 달 것만
+    }
+
+    @Test
+    @DisplayName("횟수 챌린지: 이번 달 러닝 횟수가 정확히 카운트된다")
+    @Transactional
+    void streakChallenge_CountsCurrentMonthRunningsCorrectly() {
+        // Given: 이번 달 러닝 5개 생성
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime monthStart = now.with(TemporalAdjusters.firstDayOfMonth()).withHour(0).withMinute(0).withSecond(0);
+
+        for (int i = 1; i <= 5; i++) {
+            createRunning(testUser, monthStart.plusDays(i), 5000);
+        }
+
+        // When
+        List<PersonalChallengeResponse> challenges = personalChallengeService.getPersonalChallenges(testUser);
+        PersonalChallengeResponse streakChallenge = challenges.stream()
+                .filter(c -> c.type() == ChallengeType.STREAK)
+                .findFirst()
+                .orElseThrow();
+
+        // Then
+        assertThat(streakChallenge.title()).isEqualTo("이번 달 12번 달리기");
+        assertThat(streakChallenge.goalValue()).isEqualTo(12);
+        assertThat(streakChallenge.currentValue()).isEqualTo(5);
+        assertThat(streakChallenge.progressRate()).isEqualTo(41); // 5/12 * 100
+    }
+
+    @Test
+    @DisplayName("횟수 챌린지: 목표 달성 시 진행률이 100%로 제한된다")
+    @Transactional
+    void streakChallenge_ProgressRateCappedAt100Percent() {
+        // Given: 12번 넘게 달리기
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime monthStart = now.with(TemporalAdjusters.firstDayOfMonth()).withHour(0).withMinute(0).withSecond(0);
+
+        for (int i = 1; i <= 15; i++) {
+            createRunning(testUser, monthStart.plusDays(i), 3000);
+        }
+
+        // When
+        List<PersonalChallengeResponse> challenges = personalChallengeService.getPersonalChallenges(testUser);
+        PersonalChallengeResponse streakChallenge = challenges.stream()
+                .filter(c -> c.type() == ChallengeType.STREAK)
+                .findFirst()
+                .orElseThrow();
+
+        // Then
+        assertThat(streakChallenge.currentValue()).isEqualTo(15);
+        assertThat(streakChallenge.progressRate()).isEqualTo(100); // 125%이지만 100%로 제한
+    }
+
+    @Test
+    @DisplayName("챌린지 기간이 이번 달 1일~말일로 설정된다")
+    @Transactional
+    void challenge_PeriodIsCurrentMonth() {
+        // When
+        List<PersonalChallengeResponse> challenges = personalChallengeService.getPersonalChallenges(testUser);
+        PersonalChallengeResponse challenge = challenges.get(0);
+
+        // Then
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime expectedStart = now.with(TemporalAdjusters.firstDayOfMonth())
+                .withHour(0).withMinute(0).withSecond(0).withNano(0);
+        LocalDateTime expectedEnd = now.with(TemporalAdjusters.lastDayOfMonth())
+                .withHour(23).withMinute(59).withSecond(59);
+
+        assertThat(challenge.startAt()).isEqualToIgnoringNanos(expectedStart);
+        assertThat(challenge.endAt().toLocalDate()).isEqualTo(expectedEnd.toLocalDate());
+        assertThat(challenge.endAt().getHour()).isEqualTo(23);
+        assertThat(challenge.endAt().getMinute()).isEqualTo(59);
+    }
+
+    @Test
+    @DisplayName("러닝이 없을 때 진행률이 0이다")
+    @Transactional
+    void challenge_NoRunnings_ProgressIsZero() {
+        // Given: 러닝 없음
+
+        // When
+        List<PersonalChallengeResponse> challenges = personalChallengeService.getPersonalChallenges(testUser);
+
+        // Then
+        assertThat(challenges).allMatch(c -> c.currentValue() == 0);
+        assertThat(challenges).allMatch(c -> c.progressRate() == 0);
+    }
+
+    private void createRunning(User user, LocalDateTime startedAt, int distance) {
+        runningRepository.save(Running.builder()
+                .user(user)
+                .crew(testCrew)
+                .distance(distance)
+                .duration(1800) // 30분 (초 단위)
+                .pace(360) // 6분/km (초/km)
+                .avgHeartrate((short) 150)
+                .startedAt(startedAt)
+                .build());
+    }
+}


### PR DESCRIPTION
  - 크루 챌린지와 개인 챌린지를 통합 조회하는 API 추가 (GET /api/v1/challenges)
  - 챌린지 자동 만료 처리 스케줄러 구현
  - 챌린지 초기화 기능 추가
  
## 📌 PR 개요
- 챌린지 조회 api

## 🔧 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## 🧪 테스트 방법
- 스웨거 api확인 완료, 테스트 코드 완료

## 📎 관련 이슈
- closes #번호
